### PR TITLE
Add easy setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas==1.2.0
+scipy==1.5.0
+numpy==1.19.1
+palettable==3.3.0
+matplotlib==3.2.2
+numba==0.51.2
+firefly_api==0.0.2
+h5py==3.1.0
+psutil==5.8.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="common python utilities",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/zhafen/cc",
+    url="https://github.com/agurvich/abg_python",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="abg_python",
+    version="0.1",
+    author="Alex Gurvich",
+    author_email="agurvich@u.northwestern.edu",
+    description="common python utilities",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/zhafen/cc",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    install_requires=[
+        'pandas>=1.2.0',
+        'scipy>=1.5.0',
+        'numpy>=1.19.1',
+        'palettable>=3.3.0',
+        'matplotlib>=3.2.2',
+        'numba>=0.51.2',
+        'firefly_api>=0.0.2',
+        'h5py>=3.1.0',
+        'psutil>=5.8.0',
+    ],
+)


### PR DESCRIPTION
With these two files added the user can add abg_python to their python path and install all dependencies with `pip install -e .` while in the cloned directory. The requirements were generated using [pipreqs](https://pypi.org/project/pipreqs/). The `setup.py` was copied from another project and then edited accordingly.